### PR TITLE
Fix/#9 random number

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-DATABASE_URL=mysql://root:Swimming3003@localhost/english_word_book
+DATABASE_URL=mysql://shogo:Swimming2884@0.0.0.0/english_word_book
 PORT=3000
+

--- a/front/src/pages/MainPage.tsx
+++ b/front/src/pages/MainPage.tsx
@@ -35,7 +35,7 @@ const MainPage = () => {
 
         try{
             const response = await axios.post<GenerateTestRespose>(
-                "http://54.178.56.216:3000/generate-test", 
+                "http://localhost:3000/generate-test", 
             {
                 english_word_book: englishWordBook,
                 times: times,

--- a/src/application/utils.rs
+++ b/src/application/utils.rs
@@ -41,7 +41,7 @@ pub fn generate_random_number(times: u16, start_number: u16, end_number: u16) ->
 
 pub fn generate_sql_query(book_name: &str, ids: Vec<u16>) -> String {
     let id_list = ids.iter().map(|id| id.to_string()).collect::<Vec<String>>().join(",");
-    format!("SELECT english_word, japanese_word FROM {} WHERE id IN ({})", book_name, id_list)
+    format!("SELECT english_word, japanese_word FROM {} WHERE id IN ({}) ORDER BY FIELD (id, {})", book_name, id_list, id_list)
 }
 
 pub fn range_validation(times: u16, start_number: u16, end_number: u16) -> bool {

--- a/src/infra/db.rs
+++ b/src/infra/db.rs
@@ -6,5 +6,6 @@ pub async fn execute_sql_query(pool: &MySqlPool, query: &str) -> Result<Vec<Test
     let rows: Vec<Test> = sqlx::query_as(query)
         .fetch_all(pool)
         .await?;
+    println!("sqlクエリSELECT結果: {:?}", rows);
     Ok(rows)
 }

--- a/src/presentation/handler.rs
+++ b/src/presentation/handler.rs
@@ -36,7 +36,14 @@ pub async fn generate_test_handler(
         }
     };
 
-    println!("[INFO]:[リクエスト][{}]問題数:{}, テスト範囲{}~{}: [レスポンス]要素数:{}, 生成数値{:?}", book_name,times, start_number,end_number, row_id_list.len(), row_id_list);
+    println!("[INFO]:[リクエスト][{}]問題数:{}, テスト範囲{}~{}: [レスポンス]要素数:{}, 生成数値{:?}", 
+        book_name,
+        times,
+        start_number,
+        end_number,
+        row_id_list.len(),
+        row_id_list
+    );
 
     let sql_query = generate_sql_query(&book_name, row_id_list);
 
@@ -45,7 +52,10 @@ pub async fn generate_test_handler(
     let english_words: Vec<String> = rows.iter().map(|r| r.english_word.clone()).collect();
     let japanese_words: Vec<String> = rows.iter().map(|r| r.japanese_word.clone()).collect();
 
+    println!("english_words: {:?}", english_words);
+
     let question_sheet = gen_test_pdf(english_words, japanese_words);
+
 
     let file_path = "temp_question_sheet.pdf";
     question_sheet.render_to_file(file_path).expect("Failed to write PDF file");
@@ -60,3 +70,4 @@ pub async fn generate_test_handler(
         test_data: pdf_base64,
     }))
 }
+


### PR DESCRIPTION
## プルリクエスト: 英単語テストのランダム順序保持機能の修正

## 概要
英単語テスト生成時に、ランダムに生成されたIDの順序がデータベースクエリ実行後に失われる問題を修正した。

## 変更内容

### 主要な修正
- **`src/application/utils.rs`**: `generate_sql_query`関数に`ORDER BY FIELD(id, ...)`句を追加
  ```rust
  // 修正前
  format!("SELECT english_word, japanese_word FROM {} WHERE id IN ({})", book_name, id_list)
  
  // 修正後  
  format!("SELECT english_word, japanese_word FROM {} WHERE id IN ({}) ORDER BY FIELD (id, {})", book_name, id_list, id_list)
  ```

### その他の変更
- **`src/infra/db.rs`**: SQLクエリ結果のデバッグログを追加
- **`src/presentation/handler.rs`**: ログ出力の改善とデバッグ情報の追加
- **`.env`**: データベース接続設定の更新
- **`front/src/pages/MainPage.tsx`**: APIエンドポイントの変更（開発環境用）

## 解決した問題
- ランダムに生成されたIDの順序が、データベースクエリ実行後に失われていた問題
- 最終的な英単語テストの問題順序がランダムにならなかった問題

## 動作確認
- ランダムなID生成 → データベースクエリ → ランダム順序の保持が正常に動作
- 英単語テストの問題が期待通りランダムな順序で生成される

### 技術的詳細
`ORDER BY FIELD(id, ...)`句を使用することで、MySQLに指定されたIDの順序（ランダムに生成された順序）を保持するよう指示しています。`FIELD()`関数は、第1引数の値が第2引数以降のリストの何番目にあるかを返し、その順序でソートする。